### PR TITLE
fix #6 reconnect on transfer

### DIFF
--- a/common/src/main/java/dev/terminalmc/autoreconnectrf/config/Config.java
+++ b/common/src/main/java/dev/terminalmc/autoreconnectrf/config/Config.java
@@ -55,7 +55,7 @@ public class Config {
         public boolean conditionType = defaultConditionType;
 
         public static final List<String> defaultConditionKeys = new ArrayList<>(
-                List.of("multiplayer.disconnect.banned"));
+                List.of("multiplayer.disconnect.banned", "disconnect.transfer"));
         public List<String> conditionKeys = defaultConditionKeys;
 
         public static final List<String> defaultConditionPatterns = new ArrayList<>();


### PR DESCRIPTION
This commits attempts to fix #6 which initiates an automatic reconnect on server transfers. It does so by adding the transfer disconnect reason to the default black list of keys. Alternatively this could be hard-coded, as this change does not change existing config files and realistically a reconnect is not useful at all on transfers, but I wanted it to be still configurable, although I do think hard-coding this reason would be better.